### PR TITLE
Support Regression Tasks

### DIFF
--- a/fairlib/src/base_options.py
+++ b/fairlib/src/base_options.py
@@ -203,6 +203,12 @@ class BaseOptions(object):
         parser.add_argument('--conf_file', type=str, default=None,
                             help='path to the YAML file for reproduce an an experiment')
 
+        # Regression related arguments
+        parser.add_argument('--regression',  action='store_true', default=False, 
+                            help='indicate the downstream task is regression')
+        parser.add_argument('--n_bins',  type=int, default=4, 
+                            help='number of bins for discretizing proxy labels')
+
         # Handle iPython arguments
         parser.add_argument('--f', type=str, default=None, help='path to the YAML file for reproduce an an experiment')
 
@@ -465,6 +471,11 @@ class BaseOptions(object):
             torch.cuda.manual_seed(seed)
             np.random.seed(seed)
             random.seed(seed)
+
+            # Init for regression
+            if state.regression:
+                # Set the output dim to 1
+                state.num_classes = 1
 
             # Init the dataloaders
             if state.data_dir is None:

--- a/fairlib/src/base_options.py
+++ b/fairlib/src/base_options.py
@@ -175,6 +175,8 @@ class BaseOptions(object):
                             help='number of total epochs to train (default: 100)')
         parser.add_argument('--lr', type=pos_float, default=0.003, metavar='LR',
                             help='learning rate used to actually learn stuff (default: 0.003)')
+        parser.add_argument('--weight_decay', type=float, default=0.0,
+                            help='weight decay (L2 penalty) (default: 0)')
         parser.add_argument('--epochs_since_improvement', type=pos_int, default=5,
                             help='terminate training for early stopping')
         parser.add_argument('--base_seed', type=int, default=1, metavar='S',

--- a/fairlib/src/dataloaders/__init__.py
+++ b/fairlib/src/dataloaders/__init__.py
@@ -33,7 +33,12 @@ def get_dataloaders(args):
     Returns:
         tuple: dataloaders for training set, development set, and test set.
     """
-    assert args.dataset in ["Sample", "test", "Moji", "Bios_gender", "Bios_economy", "Bios_both"], "Not implemented"
+    assert args.dataset in [
+        "Sample", "test", "Moji", 
+        "Bios_gender", "Bios_economy", "Bios_both",
+        "Valence",
+        ], "Not implemented"
+
     if args.dataset == "Moji":
         task_dataloader = DeepMojiDataset
     elif args.dataset in ["Bios_gender", "Bios_economy", "Bios_both"]:
@@ -43,6 +48,8 @@ def get_dataloaders(args):
         task_dataloader = TestDataset
     elif args.dataset == "Sample":
         task_dataloader = SampleDataset
+    elif args.dataset == "Valence":
+        task_dataloader = ValenceDataset
     else:
         pass
     

--- a/fairlib/src/dataloaders/loaders.py
+++ b/fairlib/src/dataloaders/loaders.py
@@ -140,3 +140,22 @@ class BiosDataset(BaseDataset):
             self.protected_label = data["economy_class"].astype(np.int32) # Economy
         else:
             self.protected_label = data["intersection_class"].astype(np.int32) # Intersection
+
+class ValenceDataset(BaseDataset):
+    embedding_type = "cls"
+    CV_fold = 0
+    text_type = "text"
+    def load_data(self):
+        self.filename = "valence_arousal_{}_{}.pickle".format(self.split, self.CV_fold)
+
+        data = pd.read_pickle(Path(self.args.data_dir) / self.filename)
+
+        if self.args.encoder_architecture == "Fixed":
+            self.X = list(data[self.embedding_type])
+        elif self.args.encoder_architecture == "BERT":
+            self.X = self.args.text_encoder.encoder(list(data[self.text_type]))
+        else:
+            raise NotImplementedError
+
+        self.y = data["valence"].astype(np.float64)
+        self.protected_label = data["gender"].astype(np.int32)

--- a/fairlib/src/evaluators/__init__.py
+++ b/fairlib/src/evaluators/__init__.py
@@ -26,12 +26,16 @@ def present_evaluation_scores(
     valid_scores, valid_confusion_matrices = gap_eval_scores(
         y_pred=valid_preds,
         y_true=valid_labels, 
-        protected_attribute=valid_private_labels)
+        protected_attribute=valid_private_labels,
+        args = model.args,
+        )
                 
     test_scores, test_confusion_matrices = gap_eval_scores(
         y_pred=test_preds,
         y_true=test_labels, 
-        protected_attribute=test_private_labels)
+        protected_attribute=test_private_labels,
+        args = model.args,
+        )
 
     # Save checkpoint
     save_checkpoint(

--- a/fairlib/src/networks/DyBT/fairbatch_sampler.py
+++ b/fairlib/src/networks/DyBT/fairbatch_sampler.py
@@ -133,7 +133,10 @@ class FairBatch(Sampler):
         
         self.model.eval()
 
-        criterion = torch.nn.CrossEntropyLoss(reduction='none')
+        if self.args.regression:
+            criterion = torch.nn.MSELoss(reduction='none')
+        else:
+            criterion = torch.nn.CrossEntropyLoss(reduction='none')
 
         batch_losses = []
 
@@ -151,11 +154,17 @@ class FairBatch(Sampler):
                 instance_weights = batch[3].float()
                 instance_weights = instance_weights.to(device)
 
+            if self.args.regression:
+                regression_tags = batch[5].squeeze()
+                regression_tags = regression_tags.to(device)
+
             # main model predictions
             if self.args.gated:
                 predictions = self.model(text, p_tags)
             else:
                 predictions = self.model(text)
+
+            predictions = predictions if not self.args.regression else predictions.squeeze()
 
             # add the weighted loss
             if self.args.BT is not None and self.args.BT == "Reweighting":


### PR DESCRIPTION
**Update fairlib to support regression tasks.** 

To use the original training and evaluation framework for classification tasks, we keep the y label as categorical variables and add an additional variable for the actual target value for regressions.
- We use [pandas](https://pandas.pydata.org/docs/reference/api/pandas.qcut.html#pandas-qcut) to discretize regression targets. Specifically, the number of bins is specified as a hyperparameter, and each bin has the same size. 
- The regressor is trained to minimize MSE loss, and other settings are exactly the same as the classification model.
- We currently report MAE, MSE, and R2 as the regression performance metrics.
- Debiasing and fairness evaluation are largely based on bin labels, so we can still report metrics like TPR GAP and FNR GAP 
- We have also updated FairBatch to support regression debiasing, where loss estimation and resampling probability adjustment are based on MSE loss.