### PR TITLE
init hidden layers earlier

### DIFF
--- a/fairlib/src/networks/classifier.py
+++ b/fairlib/src/networks/classifier.py
@@ -25,10 +25,11 @@ class MLP(BaseModel):
 
         # Init batch norm, dropout, and activation function
         self.init_hyperparameters()
-        self.cls_parameter = self.get_cls_parameter()
 
         # Init hidden layers
         self.hidden_layers = self.init_hidden_layers()
+
+        self.cls_parameter = self.get_cls_parameter()
 
         # Augmentation layers
         if self.args.gated:


### PR DESCRIPTION
When adv_level was set to "input", `get_cls_parameter()` could not get `self.hidden_layers.parameters()` as the hidden layers were not initialised yet, throwing 

`AttributeError: 'MLP' object has no attribute 'hidden_layers'`.

I've changed the code so that the hidden layer init happens earlier.